### PR TITLE
Refactor imports and move precompute tasks to constants

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,8 @@ from src.components import navmenu
 from src.components.callbacks import create_feedback_button
 from src.utils.telemetry import log_request, get_client_ip, is_development_ip, maintain_ip_locations
 from src.config.cache import cache, initialize_cache
-from src.config.precompute import precompute_tasks,precompute_all
+from src.config.constants import precompute_tasks
+from src.config.precompute import precompute_all
 from src.config.database import TelemetrySession, SubmissionsSession
 from src.database.init_db import init_databases
 

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -1,0 +1,20 @@
+from src.database.sql_manager import (
+    fetch_meta_data,
+    fetch_paper_data,
+    fetch_ship_table,
+    fetch_all_ships,
+    get_database_stats,
+    fetch_download_data
+)
+
+precompute_tasks = {
+    "meta_data": lambda: fetch_meta_data(curated=True),
+    "paper_data": fetch_paper_data,
+    "ship_table": fetch_ship_table,
+    "all_ships": fetch_all_ships,
+    "database_stats": get_database_stats,
+    "download_data_curated_true_derep_false": lambda: fetch_download_data(curated=True, dereplicate=False),
+    "download_data_curated_true_derep_true": lambda: fetch_download_data(curated=True, dereplicate=True),
+    "download_data_curated_false_derep_false": lambda: fetch_download_data(curated=False, dereplicate=False),
+    "download_data_curated_false_derep_true": lambda: fetch_download_data(curated=False, dereplicate=True),
+}

--- a/src/config/precompute.py
+++ b/src/config/precompute.py
@@ -1,27 +1,9 @@
 import logging
 from src.config.cache import cache
-from src.database.sql_manager import (
-    fetch_meta_data,
-    fetch_paper_data,
-    fetch_ship_table,
-    fetch_all_ships,
-    get_database_stats,
-    fetch_download_data
-)
 
 logger = logging.getLogger(__name__)
 
-precompute_tasks = {
-    "meta_data": lambda: fetch_meta_data(curated=True),
-    "paper_data": fetch_paper_data,
-    "ship_table": fetch_ship_table,
-    "all_ships": fetch_all_ships,
-    "database_stats": get_database_stats,
-    "download_data_curated_true_derep_false": lambda: fetch_download_data(curated=True, dereplicate=False),
-    "download_data_curated_true_derep_true": lambda: fetch_download_data(curated=True, dereplicate=True),
-    "download_data_curated_false_derep_false": lambda: fetch_download_data(curated=False, dereplicate=False),
-    "download_data_curated_false_derep_true": lambda: fetch_download_data(curated=False, dereplicate=True),
-}
+from src.config.constants import precompute_tasks
 
 def precompute_all():
     """Precompute and cache all necessary data and figures."""

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 # Get the project root directory (where the app runs from)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/src/database/sql_manager.py
+++ b/src/database/sql_manager.py
@@ -1,10 +1,6 @@
-import os
-import pickle
 from typing import Any
 import logging
 import pandas as pd
-from flask_caching import Cache
-from src.config.cache import cache
 from src.config.database import StarbaseSession
 from src.utils.plot_utils import create_sunburst_plot
 


### PR DESCRIPTION
To avoid circular imports, separated precompute tasks into a separate module. These should not be within `app.py`.