### PR TITLE
Starbase Blast search bug fix

### DIFF
--- a/src/pages/home.py
+++ b/src/pages/home.py
@@ -233,10 +233,7 @@ developing_features_card = dmc.Paper(
             mb="md",
         ),
         dmc.List(
-            [
-                dmc.ListItem(dmc.Text(item, c="dimmed"))
-                for item in not_working
-            ],
+            [dmc.ListItem(dmc.Text(item, c="dimmed")) for item in not_working],
             size="lg",
             spacing="sm",
         ),

--- a/src/pages/home.py
+++ b/src/pages/home.py
@@ -234,7 +234,7 @@ developing_features_card = dmc.Paper(
         ),
         dmc.List(
             [
-                dmc.ListItem(dmc.Text(item, size="lg", c="dimmed"))
+                dmc.ListItem(dmc.Text(item, c="dimmed"))
                 for item in not_working
             ],
             size="lg",

--- a/src/utils/blast_utils.py
+++ b/src/utils/blast_utils.py
@@ -560,14 +560,13 @@ def create_no_matches_alert():
             dmc.List(
                 [
                     dmc.ListItem(
-                        "Check if your sequence is in the correct format", size="sm"
+                        "Check if your sequence is in the correct format",
                     ),
                     dmc.ListItem(
                         "Try searching with a different region of your sequence",
-                        size="sm",
                     ),
                     dmc.ListItem(
-                        "Consider using a less stringent E-value threshold", size="sm"
+                        "Consider using a less stringent E-value threshold",
                     ),
                 ],
                 withPadding=True,

--- a/src/utils/seq_utils.py
+++ b/src/utils/seq_utils.py
@@ -288,7 +288,7 @@ def parse_fasta_from_text(text, format="fasta"):
             )
 
         logger.info(f"Successfully parsed sequence: {header} ({len(seq)} bp)")
-        return header, seq, None
+        return header, seq
 
     except ValueError as ve:
         logger.error(f"Value error in parse_fasta_from_text: {ve}")


### PR DESCRIPTION
### **This PR resolves 2 issues in the Blast search tab of Starbase**

1. Dash component error message seen below: this is resolved by removing the `sm` argument from the `dmc.ListItem` as it is not supported for this version.

2. Enable text search for a Fasta sequence by adjusting the number of items returned from the `parse_fasta_from_text` function.


<img width="1497" alt="starbase_sm_before" src="https://github.com/user-attachments/assets/f2a5cf53-a202-4b92-9f5e-6fe6f9949ae3" />

<img width="1502" alt="starbase_sm_after" src="https://github.com/user-attachments/assets/0f0963f7-0f08-4448-89d1-10ac39db84fb" />
