### PR TITLE
Refactor: move directory creation logic to start of script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 COPY ./ ./
 
 # Create necessary directories and set permissions
-RUN mkdir -p /var/run/crond /var/log/cron $HOME/cron && \
+RUN mkdir -p /var/run/crond /var/log/cron $HOME/cron $HOME/src/database && \
     touch /var/log/cron/cron.log && \
     # Create crontab file for supercronic
     echo "0 * * * * cd $HOME && python -m src.utils.telemetry update_ip_locations >> $HOME/cron/cron.log 2>&1" > $HOME/cron/crontab && \

--- a/start-script.sh
+++ b/start-script.sh
@@ -7,9 +7,14 @@ if [ ! -x "$0" ]; then
     exit 1
 fi
 
-# Create and set permissions for cache directory
-mkdir -p $HOME/src/database/db/cache/tmp
-chmod -R 777 $HOME/src/database/db/cache
+# Ensure all necessary directories exist and have correct permissions
+for dir in "$HOME/src/database/db" "$HOME/src/database/db/cache" "$HOME/src/database/db/tmp"; do
+    if [ ! -d "$dir" ]; then
+        echo "Directory does not exist, creating: $dir"
+        mkdir -p "$dir"
+    fi
+    chmod -R 777 "$dir"
+done
 
 # Start Redis server in the background if not using external Redis
 redis-server --daemonize yes


### PR DESCRIPTION
Moves directory creation and permission logic to the start of start-script.sh for reliability and clarity.