### PR TITLE
Switch cache and Celery temp files to RAM disk (/dev/shm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 COPY ./ ./
 
 # Create necessary directories and set permissions
-RUN mkdir -p /var/run/crond /var/log/cron $HOME/cron $HOME/src/database && \
+RUN mkdir -p /var/run/crond /var/log/cron $HOME/cron $HOME/src/database /dev/shm/starbase_cache/tmp /dev/shm/starbase_cache/celery && \
     touch /var/log/cron/cron.log && \
     # Create crontab file for supercronic
     echo "0 * * * * cd $HOME && python -m src.utils.telemetry update_ip_locations >> $HOME/cron/cron.log 2>&1" > $HOME/cron/crontab && \
@@ -60,7 +60,7 @@ RUN mkdir -p /var/run/crond /var/log/cron $HOME/cron $HOME/src/database && \
     chown $USER:$USER $HOME/start-script.sh && \
     chown -R $USER:$USER $HOME /var/run/crond /var/log/cron && \
     chmod -R 755 $HOME && \
-    chmod -R 777 /var/run/crond /var/log/cron
+    chmod -R 777 /var/run/crond /var/log/cron /dev/shm/starbase_cache
 
 # Set conda environment to activate by default
 SHELL ["conda", "run", "-n", "starbase", "/bin/bash", "-c"]

--- a/src/config/cache.py
+++ b/src/config/cache.py
@@ -2,13 +2,13 @@ from flask_caching import Cache
 import os
 import time
 
-from src.config.settings import DATA_DIR
 
 from src.config.logging import get_logger
 
 logger = get_logger(__name__)
 
-cache_dir = os.path.join(DATA_DIR, "cache")
+# Use /dev/shm for temporary storage
+cache_dir = "/dev/shm/starbase_cache"
 os.makedirs(cache_dir, exist_ok=True)
 
 # Create tmp directory


### PR DESCRIPTION
## Summary

This PR switches all cache and Celery temporary file storage to a RAM disk at `/dev/shm/starbase_cache`. This improves performance and avoids persistent volume permission issues in Kubernetes.

## Changes

- Updates `src/config/cache.py` to use `/dev/shm/starbase_cache` for cache storage.
- Updates `start-script.sh` to create and set permissions for RAM disk directories, and to store Celery PID and schedule files in RAM disk.
- Updates `Dockerfile` to create RAM disk directories at build time.

## Motivation

- Fixes issues with file permissions and persistence when using Kubernetes volume mounts.
- Improves performance by using in-memory storage for temporary files.
- Ensures all temporary files are cleaned up on container restart.