### PR TITLE
do not exclude the mount dir from docker builds, it needs to exist for the volume to be mounted

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,7 @@ alembic/
 alembic.ini
 .cache
 src/data/db.tar.gz
-src/database/db/
+src/database/db/*
 *.db
 *.sqlite
 *.sqlite3


### PR DESCRIPTION
mistakenly changed  in the  to . This directory needs to be present in the docker container for the volume to be properly mounted and accessible.