### PR TITLE
Add conda environment activation in start-script.sh

### DIFF
--- a/start-script.sh
+++ b/start-script.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e  # Exit on error
 
+# Activate conda environment if not already activated
+if [[ -z "$CONDA_PREFIX" || "$CONDA_PREFIX" != *"/starbase" ]]; then
+    source $(conda info --base)/etc/profile.d/conda.sh
+    conda activate starbase
+fi
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in


### PR DESCRIPTION
running commands in the start-script resulted in errors because these commands (i.e. `celery` and `uvicorn`) aren't found in the deployment environment, even though they work in Docker.

To deploy successfully:
1. Make sure `conda` is installed in deployment environment
2. Ensure `environment.yaml` file is present and the `conda` environment is created before running
3. Script path `$(conda info --base)` must be accessible in deployment environment