### PR TITLE
run_classification_workflow should not use nested tasks and use redis from within the container

### DIFF
--- a/src/config/celery_config.py
+++ b/src/config/celery_config.py
@@ -1,31 +1,30 @@
 from celery import Celery
-from src.config.settings import DATA_DIR
 import os
 
 # Redis configuration
-CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
-CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0')
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
 
 # Initialize Celery
-celery = Celery('starships')
+celery = Celery("starships")
 
 # Configure using settings
 celery.conf.update(
     broker_url=CELERY_BROKER_URL,
     result_backend=CELERY_RESULT_BACKEND,
-    task_serializer='json',
-    result_serializer='json',
-    accept_content=['json'],
+    task_serializer="pickle",
+    result_serializer="pickle",
+    accept_content=["json", "pickle"],
     imports=[
-        'src.tasks',  # Make sure this is included
+        "src.tasks",  # Make sure this is included
     ],
     worker_prefetch_multiplier=1,  # Disable prefetching for more predictable behavior
     task_time_limit=300,  # 5 minute timeout
     task_soft_time_limit=90,  # Soft timeout of 1.5 minutes
     task_track_started=True,
-    timezone='UTC',
+    timezone="UTC",
     enable_utc=True,
 )
 
 # This ensures tasks are properly registered
-celery.autodiscover_tasks(['src.tasks']) 
+celery.autodiscover_tasks(["src.tasks"])

--- a/start-script.sh
+++ b/start-script.sh
@@ -3,6 +3,9 @@
 # Start Redis server in the background if not using external Redis
 redis-server --daemonize yes
 
+# Add check to verify Redis is running
+redis-cli ping || { echo "Redis failed to start"; exit 1; }
+
 # Start cron in the background using supercronic
 supercronic $HOME/cron/crontab &
 


### PR DESCRIPTION
Identified two main issues impacting the running of BLAST/classification pipeline with celery worker(s):
- the paths used for celery broker and backend were expected to connect to a redis service in another kubernetes pod
- `run_classification_workflow` contained nested tasks. this could result in:
  1. Deadlock potential: If all worker processes are busy executing the parent task, there may not be workers available for the subtasks.
  2. Task replacement: In Kubernetes, this pattern is particularly problematic and causes the tasks to be replaced with stub implementations (return 1), which is exactly what your logs show.
  3. Redis connectivity: The parent task may have a connection to Redis, but the child tasks might not properly inherit that connection in the containerized environment.
  
- instead, we are now:
  - Keeping all work within a single Celery worker
  - Avoiding task serialization/deserialization issues
  - using redis from within the pod