### PR TITLE
soft delete, database migrations, wiki search update

### DIFF
--- a/alembic/versions/i2j3k4l5m6n7_add_metadata_views.py
+++ b/alembic/versions/i2j3k4l5m6n7_add_metadata_views.py
@@ -1,0 +1,123 @@
+"""add ships_with_metadata, captains_with_metadata, ship_table_view
+
+Merges the 4 divergent heads and adds read-only SQL views that mirror the
+JOINs previously duplicated as inline CTEs/queries in sql_manager.py:
+- ships_with_metadata: mirrors fetch_ships()'s CTE (full join incl. captains/features)
+- captains_with_metadata: mirrors fetch_captains()'s CTE
+- ship_table_view: mirrors fetch_ship_table()'s narrower join (no features/genomes/
+  navis/haplotype/captains, to avoid introducing row fan-out from starship_features)
+
+Revision ID: i2j3k4l5m6n7
+Revises: 8adfce5239bb, f1a2b3c4d5e6, f8e9a1b2c3d4, h1i2j3k4l5m6
+Create Date: 2026-07-23
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "i2j3k4l5m6n7"
+down_revision: Union[str, Sequence[str], None] = (
+    "8adfce5239bb",
+    "f1a2b3c4d5e6",
+    "f8e9a1b2c3d4",
+    "h1i2j3k4l5m6",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS ships_with_metadata")
+    op.execute("""
+        CREATE VIEW ships_with_metadata AS
+        SELECT DISTINCT
+            j.id as joined_ship_id,
+            j.ship_id,
+            j.source,
+            j.evidence,
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            j.curated_status,
+            j.starshipID,
+            sf.elementBegin, sf.elementEnd, sf.elementLength, sf.contigID, sf.upDR, sf.downDR,
+            t.name, t.family, t."order", t.taxID, t.strain,
+            f.familyName, f.type_element_reference,
+            n.navis_name, n.activity as navis_activity,
+            h.haplotype_name, h.activity as haplotype_activity,
+            g.ome, g.version as genome_version, g.genomeSource, g.citation, g.assembly_accession,
+            c.captainID,
+            a.accession_tag, a.version_tag, a.accession_display,
+            s.sequence, s.md5, s.rev_comp_md5, s.type_ship
+        FROM joined_ships j
+        LEFT JOIN ships s ON s.id = j.ship_id
+        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
+        LEFT JOIN taxonomy t ON j.tax_id = t.id
+        LEFT JOIN family_names f ON j.ship_family_id = f.id
+        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
+        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
+        LEFT JOIN genomes g ON j.genome_id = g.id
+        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
+        LEFT JOIN captains c ON j.captain_id = c.id
+        LEFT JOIN accessions a ON j.accession_id = a.id
+        WHERE j.ship_id IS NOT NULL
+    """)
+
+    op.execute("DROP VIEW IF EXISTS captains_with_metadata")
+    op.execute("""
+        CREATE VIEW captains_with_metadata AS
+        SELECT DISTINCT
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            j.curated_status,
+            j.starshipID,
+            c.id as captain_row_id,
+            c.captainID,
+            c.sequence as captain_sequence,
+            n.navis_name,
+            h.haplotype_name,
+            a.accession_tag,
+            a.version_tag,
+            a.accession_display
+        FROM joined_ships j
+        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
+        LEFT JOIN taxonomy t ON j.tax_id = t.id
+        LEFT JOIN family_names f ON j.ship_family_id = f.id
+        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
+        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
+        LEFT JOIN genomes g ON j.genome_id = g.id
+        LEFT JOIN captains c ON j.captain_id = c.id
+        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
+        LEFT JOIN accessions a ON j.accession_id = a.id
+        WHERE j.ship_id IS NOT NULL
+    """)
+
+    op.execute("DROP VIEW IF EXISTS ship_table_view")
+    op.execute("""
+        CREATE VIEW ship_table_view AS
+        SELECT DISTINCT
+            js.ship_id,
+            js.source,
+            js.curated_status,
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            f.familyName,
+            t.name,
+            a.accession_tag, a.version_tag, a.accession_display
+        FROM joined_ships js
+        LEFT JOIN ship_accessions sa ON sa.ship_id = js.ship_id
+        LEFT JOIN taxonomy t ON js.tax_id = t.id
+        LEFT JOIN family_names f ON js.ship_family_id = f.id
+        LEFT JOIN accessions a ON js.accession_id = a.id
+        WHERE js.ship_id IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS ship_table_view")
+    op.execute("DROP VIEW IF EXISTS captains_with_metadata")
+    op.execute("DROP VIEW IF EXISTS ships_with_metadata")

--- a/alembic/versions/j3k4l5m6n7o8_add_ship_accession_fk_and_soft_delete.py
+++ b/alembic/versions/j3k4l5m6n7o8_add_ship_accession_fk_and_soft_delete.py
@@ -1,0 +1,143 @@
+"""add ship_accession_id fk and is_deleted soft-delete flag to joined_ships
+
+joined_ships already links directly to accessions (SSA, group-level) via
+accession_id. The SSB (ship-level) link only existed indirectly, via
+joined_ships.ship_id -> ships.id -> ship_accessions.ship_id. This adds a
+direct ship_accession_id FK on joined_ships mirroring accession_id, and
+backfills it from the existing ship_id linkage.
+
+Also adds is_deleted (soft delete flag) to joined_ships, and updates the
+3 metadata views (see i2j3k4l5m6n7) to exclude soft-deleted rows so every
+existing caller gets safe behavior with no code changes.
+
+Revision ID: j3k4l5m6n7o8
+Revises: i2j3k4l5m6n7
+Create Date: 2026-07-24
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "j3k4l5m6n7o8"
+down_revision: Union[str, None] = "i2j3k4l5m6n7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE joined_ships ADD COLUMN ship_accession_id INTEGER REFERENCES ship_accessions(id)"
+    )
+    op.execute("""
+        UPDATE joined_ships
+        SET ship_accession_id = (
+            SELECT sa.id FROM ship_accessions sa WHERE sa.ship_id = joined_ships.ship_id
+        )
+        WHERE ship_id IS NOT NULL
+    """)
+
+    op.execute(
+        "ALTER TABLE joined_ships ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT 0"
+    )
+
+    _create_views(deleted_filter=True)
+
+
+def downgrade() -> None:
+    _create_views(deleted_filter=False)
+
+    op.execute("ALTER TABLE joined_ships DROP COLUMN is_deleted")
+    op.execute("ALTER TABLE joined_ships DROP COLUMN ship_accession_id")
+
+
+def _create_views(deleted_filter: bool) -> None:
+    deleted_clause = "AND j.is_deleted = 0" if deleted_filter else ""
+
+    op.execute("DROP VIEW IF EXISTS ships_with_metadata")
+    op.execute(f"""
+        CREATE VIEW ships_with_metadata AS
+        SELECT DISTINCT
+            j.id as joined_ship_id,
+            j.ship_id,
+            j.source,
+            j.evidence,
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            j.curated_status,
+            j.starshipID,
+            sf.elementBegin, sf.elementEnd, sf.elementLength, sf.contigID, sf.upDR, sf.downDR,
+            t.name, t.family, t."order", t.taxID, t.strain,
+            f.familyName, f.type_element_reference,
+            n.navis_name, n.activity as navis_activity,
+            h.haplotype_name, h.activity as haplotype_activity,
+            g.ome, g.version as genome_version, g.genomeSource, g.citation, g.assembly_accession,
+            c.captainID,
+            a.accession_tag, a.version_tag, a.accession_display,
+            s.sequence, s.md5, s.rev_comp_md5, s.type_ship
+        FROM joined_ships j
+        LEFT JOIN ships s ON s.id = j.ship_id
+        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
+        LEFT JOIN taxonomy t ON j.tax_id = t.id
+        LEFT JOIN family_names f ON j.ship_family_id = f.id
+        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
+        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
+        LEFT JOIN genomes g ON j.genome_id = g.id
+        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
+        LEFT JOIN captains c ON j.captain_id = c.id
+        LEFT JOIN accessions a ON j.accession_id = a.id
+        WHERE j.ship_id IS NOT NULL {deleted_clause}
+    """)
+
+    op.execute("DROP VIEW IF EXISTS captains_with_metadata")
+    op.execute(f"""
+        CREATE VIEW captains_with_metadata AS
+        SELECT DISTINCT
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            j.curated_status,
+            j.starshipID,
+            c.id as captain_row_id,
+            c.captainID,
+            c.sequence as captain_sequence,
+            n.navis_name,
+            h.haplotype_name,
+            a.accession_tag,
+            a.version_tag,
+            a.accession_display
+        FROM joined_ships j
+        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
+        LEFT JOIN taxonomy t ON j.tax_id = t.id
+        LEFT JOIN family_names f ON j.ship_family_id = f.id
+        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
+        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
+        LEFT JOIN genomes g ON j.genome_id = g.id
+        LEFT JOIN captains c ON j.captain_id = c.id
+        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
+        LEFT JOIN accessions a ON j.accession_id = a.id
+        WHERE j.ship_id IS NOT NULL {deleted_clause}
+    """)
+
+    op.execute("DROP VIEW IF EXISTS ship_table_view")
+    op.execute(f"""
+        CREATE VIEW ship_table_view AS
+        SELECT DISTINCT
+            js.ship_id,
+            js.source,
+            js.curated_status,
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            f.familyName,
+            t.name,
+            a.accession_tag, a.version_tag, a.accession_display
+        FROM joined_ships js
+        LEFT JOIN ship_accessions sa ON sa.ship_id = js.ship_id
+        LEFT JOIN taxonomy t ON js.tax_id = t.id
+        LEFT JOIN family_names f ON js.ship_family_id = f.id
+        LEFT JOIN accessions a ON js.accession_id = a.id
+        WHERE js.ship_id IS NOT NULL {deleted_clause.replace("j.", "js.")}
+    """)

--- a/alembic/versions/k4l5m6n7o8p9_add_taxonomy_hierarchy_to_ships_view.py
+++ b/alembic/versions/k4l5m6n7o8p9_add_taxonomy_hierarchy_to_ships_view.py
@@ -1,0 +1,98 @@
+"""add genus/species/class taxonomy columns to ships_with_metadata
+
+wiki.py's taxa search is being fixed to search exactly: name, class, order,
+family, genus, species. order/family/name were already present in
+ships_with_metadata (and therefore fetch_meta_data, which backs the wiki page's
+meta-data store), but genus, species, and class were never selected from
+taxonomy -- so search on those 3 levels was always a silent no-op.
+
+Revision ID: k4l5m6n7o8p9
+Revises: j3k4l5m6n7o8
+Create Date: 2026-07-24
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "k4l5m6n7o8p9"
+down_revision: Union[str, None] = "j3k4l5m6n7o8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS ships_with_metadata")
+    op.execute("""
+        CREATE VIEW ships_with_metadata AS
+        SELECT DISTINCT
+            j.id as joined_ship_id,
+            j.ship_id,
+            j.source,
+            j.evidence,
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            j.curated_status,
+            j.starshipID,
+            sf.elementBegin, sf.elementEnd, sf.elementLength, sf.contigID, sf.upDR, sf.downDR,
+            t.name, t.genus, t.species, t.family, t."order", t.class, t.taxID, t.strain,
+            f.familyName, f.type_element_reference,
+            n.navis_name, n.activity as navis_activity,
+            h.haplotype_name, h.activity as haplotype_activity,
+            g.ome, g.version as genome_version, g.genomeSource, g.citation, g.assembly_accession,
+            c.captainID,
+            a.accession_tag, a.version_tag, a.accession_display,
+            s.sequence, s.md5, s.rev_comp_md5, s.type_ship
+        FROM joined_ships j
+        LEFT JOIN ships s ON s.id = j.ship_id
+        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
+        LEFT JOIN taxonomy t ON j.tax_id = t.id
+        LEFT JOIN family_names f ON j.ship_family_id = f.id
+        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
+        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
+        LEFT JOIN genomes g ON j.genome_id = g.id
+        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
+        LEFT JOIN captains c ON j.captain_id = c.id
+        LEFT JOIN accessions a ON j.accession_id = a.id
+        WHERE j.ship_id IS NOT NULL AND j.is_deleted = 0
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS ships_with_metadata")
+    op.execute("""
+        CREATE VIEW ships_with_metadata AS
+        SELECT DISTINCT
+            j.id as joined_ship_id,
+            j.ship_id,
+            j.source,
+            j.evidence,
+            sa.ship_accession_tag,
+            sa.ship_version_tag,
+            sa.ship_accession_display,
+            j.curated_status,
+            j.starshipID,
+            sf.elementBegin, sf.elementEnd, sf.elementLength, sf.contigID, sf.upDR, sf.downDR,
+            t.name, t.family, t."order", t.taxID, t.strain,
+            f.familyName, f.type_element_reference,
+            n.navis_name, n.activity as navis_activity,
+            h.haplotype_name, h.activity as haplotype_activity,
+            g.ome, g.version as genome_version, g.genomeSource, g.citation, g.assembly_accession,
+            c.captainID,
+            a.accession_tag, a.version_tag, a.accession_display,
+            s.sequence, s.md5, s.rev_comp_md5, s.type_ship
+        FROM joined_ships j
+        LEFT JOIN ships s ON s.id = j.ship_id
+        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
+        LEFT JOIN taxonomy t ON j.tax_id = t.id
+        LEFT JOIN family_names f ON j.ship_family_id = f.id
+        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
+        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
+        LEFT JOIN genomes g ON j.genome_id = g.id
+        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
+        LEFT JOIN captains c ON j.captain_id = c.id
+        LEFT JOIN accessions a ON j.accession_id = a.id
+        WHERE j.ship_id IS NOT NULL AND j.is_deleted = 0
+    """)

--- a/src/database/models/schema.py
+++ b/src/database/models/schema.py
@@ -260,6 +260,9 @@ class JoinedShips(Base):
 
     # Direct link to accession (when sequence data is available)
     accession_id = Column(Integer, ForeignKey("accessions.id"), nullable=True)
+    # Direct link to ship-level (SSB) accession; mirrors accession_id (SSA, group-level).
+    # Previously only reachable via ship_id -> ships.id -> ship_accessions.ship_id.
+    ship_accession_id = Column(Integer, ForeignKey("ship_accessions.id"), nullable=True)
 
     # Links to classification and annotation data
     ship_id = Column(Integer, ForeignKey("ships.id"))
@@ -271,9 +274,11 @@ class JoinedShips(Base):
     ship_haplotype_id = Column(Integer, ForeignKey("haplotype_names.id"))
     created_at = Column(DateTime)
     updated_at = Column(DateTime)
+    is_deleted = Column(Boolean, nullable=False, default=False, server_default="0")
 
     # Relationships
     accession = relationship("Accessions", back_populates="joined_ship")
+    ship_accession = relationship("ShipAccessions")
     ship = relationship("Ships")
     family = relationship("FamilyNames")
     taxonomy = relationship("Taxonomy")

--- a/src/database/sql_manager.py
+++ b/src/database/sql_manager.py
@@ -572,7 +572,7 @@ def get_database_stats():
     LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
     LEFT JOIN taxonomy t ON j.tax_id = t.id
     LEFT JOIN ships s ON s.id = j.ship_id
-    WHERE j.ship_id IS NOT NULL
+    WHERE j.ship_id IS NOT NULL AND j.is_deleted = 0
     """
     with get_starbase_session() as session:
         try:

--- a/src/database/sql_manager.py
+++ b/src/database/sql_manager.py
@@ -55,7 +55,7 @@ def fetch_meta_data(curated=False, accessions=None):
                     ship_accession_tag,
                     ship_version_tag,
                     ship_accession_display,
-                    taxID, strain, "order", family, name,
+                    taxID, strain, "order", family, name, genus, species, "class",
                     elementLength, upDR, downDR, contigID, captainID, elementBegin, elementEnd,
                     familyName, type_element_reference, navis_name, navis_activity, haplotype_name, haplotype_activity,
                     ome, genome_version as version, genomeSource, citation, assembly_accession,

--- a/src/database/sql_manager.py
+++ b/src/database/sql_manager.py
@@ -709,6 +709,43 @@ def remove_quality_tag(joined_ship_id, tag_type):
             raise
 
 
+def set_ship_deleted(joined_ship_id, deleted=True):
+    """
+    Toggle the soft-delete flag on a joined_ships record.
+
+    Soft-deleted ships are excluded from ships_with_metadata,
+    captains_with_metadata, and ship_table_view automatically.
+
+    Args:
+        joined_ship_id (int): ID of the joined_ships record
+        deleted (bool): True to soft-delete, False to restore
+
+    Returns:
+        bool: True if a row was updated, False if not found
+    """
+    from src.database.models.schema import JoinedShips
+
+    with get_starbase_session() as session:
+        try:
+            joined_ship = (
+                session.query(JoinedShips).filter_by(id=joined_ship_id).first()
+            )
+            if not joined_ship:
+                logger.warning(f"joined_ships row {joined_ship_id} not found")
+                return False
+
+            joined_ship.is_deleted = deleted
+            session.commit()
+            logger.info(
+                f"Set is_deleted={deleted} for joined_ships row {joined_ship_id}"
+            )
+            return True
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Error setting soft-delete flag: {str(e)}")
+            raise
+
+
 def get_quality_tags(joined_ship_id):
     """
     Get all quality tags for a ship.

--- a/src/database/sql_manager.py
+++ b/src/database/sql_manager.py
@@ -50,28 +50,18 @@ def fetch_meta_data(curated=False, accessions=None):
                     full_df = pd.DataFrame.from_dict(full_df["pandas_df"])
             else:
                 meta_query = """
-                SELECT j.curated_status, j.starshipID,
-                    j.ship_id, j.id as joined_ship_id,
-                    sa.ship_accession_tag,
-                    sa.ship_version_tag,
-                    sa.ship_accession_display,
-                    t.taxID, t.strain, t.`order`, t.family, t.name,
-                    sf.elementLength, sf.upDR, sf.downDR, sf.contigID, sf.captainID, sf.elementBegin, sf.elementEnd,
-                    f.familyName, f.type_element_reference, n.navis_name, n.activity as navis_activity, h.haplotype_name, h.activity as haplotype_activity,
-                    g.ome, g.version, g.genomeSource, g.citation, g.assembly_accession,
-                    s.md5, s.rev_comp_md5, s.type_ship,
-                    a.accession_tag, a.version_tag, a.accession_display
-                FROM joined_ships j
-                LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
-                LEFT JOIN taxonomy t ON j.tax_id = t.id
-                LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
-                LEFT JOIN family_names f ON j.ship_family_id = f.id
-                LEFT JOIN navis_names n ON j.ship_navis_id = n.id
-                LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
-                LEFT JOIN genomes g ON j.genome_id = g.id
-                LEFT JOIN ships s ON s.id = j.ship_id
-                LEFT JOIN accessions a ON j.accession_id = a.id
-                WHERE j.ship_id IS NOT NULL
+                SELECT curated_status, starshipID,
+                    ship_id, joined_ship_id,
+                    ship_accession_tag,
+                    ship_version_tag,
+                    ship_accession_display,
+                    taxID, strain, "order", family, name,
+                    elementLength, upDR, downDR, contigID, captainID, elementBegin, elementEnd,
+                    familyName, type_element_reference, navis_name, navis_activity, haplotype_name, haplotype_activity,
+                    ome, genome_version as version, genomeSource, citation, assembly_accession,
+                    md5, rev_comp_md5, type_ship,
+                    accession_tag, version_tag, accession_display
+                FROM ships_with_metadata
                 """
 
                 full_df = pd.read_sql_query(meta_query, session.bind)
@@ -171,81 +161,13 @@ def fetch_ships(
     accession_mode = _get_accession_mode(accessions)
 
     with get_starbase_session() as session:
-        # CTE: denormalized ships (joined_ships + display metadata). Not validation—just one place for the join.
-        base_query = """
-        WITH ships_with_metadata AS (
-            SELECT DISTINCT
-                j.ship_id,
-                sa.ship_accession_tag,
-                sa.ship_version_tag,
-                sa.ship_accession_display,
-                j.curated_status,
-                j.starshipID,
-                sf.elementBegin, sf.elementEnd, sf.contigID,
-                t.name, t.family, t.`order`,
-                f.familyName, n.navis_name, h.haplotype_name,
-                g.assembly_accession, c.captainID,
-                a.accession_tag, a.version_tag, a.accession_display,
-                s.type_ship
-                """
-
-        base_query += """
-            FROM joined_ships j
-            LEFT JOIN ships s ON s.id = j.ship_id
-            LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
-            LEFT JOIN taxonomy t ON j.tax_id = t.id
-            LEFT JOIN family_names f ON j.ship_family_id = f.id
-            LEFT JOIN navis_names n ON j.ship_navis_id = n.id
-            LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
-            LEFT JOIN genomes g ON j.genome_id = g.id
-            LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
-            LEFT JOIN captains c ON j.captain_id = c.id
-            LEFT JOIN accessions a ON j.accession_id = a.id
-            WHERE 1=1 AND j.ship_id IS NOT NULL
-        """
-
-        query = base_query
-
-        if accessions:
-            formatted_values = [str(tag).strip("'\"") for tag in accessions]
-            quoted_sql = ", ".join(
-                "'" + str(v).replace("'", "''") + "'" for v in formatted_values
-            )
-            # Match base accession with or without version suffix
-            like_clauses = " OR ".join(
-                "a.accession_tag LIKE '" + str(v).replace("'", "''") + ".%'"
-                for v in formatted_values
-            )
-            ship_like_clauses = " OR ".join(
-                "sa.ship_accession_tag LIKE '" + str(v).replace("'", "''") + ".%'"
-                for v in formatted_values
-            )
-
-            if accession_mode == "SSA":
-                query += " AND (a.accession_tag IN ({}) OR ({}))".format(
-                    quoted_sql, like_clauses
-                )
-            elif accession_mode == "SSB":
-                query += " AND (sa.ship_accession_tag IN ({}) OR ({}))".format(
-                    quoted_sql, ship_like_clauses
-                )
-            elif accession_mode is None:
-                # Mixed or unknown: match either column (e.g. download with mixed SSA/SSB or null SSA)
-                query += " AND ((a.accession_tag IN ({}) OR ({})) OR (sa.ship_accession_tag IN ({}) OR ({})))".format(
-                    quoted_sql,
-                    like_clauses,
-                    quoted_sql,
-                    ship_like_clauses,
-                )
-            else:
-                raise ValueError(f"Invalid accession mode: {accession_mode}")
-        if curated:
-            query += " AND j.curated_status = 'curated'"
-
+        # ships_with_metadata is a real SQL view (see alembic/versions/i2j3k4l5m6n7_*)
+        # mirroring the join previously duplicated here as an inline CTE. Column
+        # list kept narrow (not SELECT *) so DISTINCT collapses the same rows it
+        # used to -- the view carries extra columns (sequence, feature detail)
+        # that would otherwise widen the distinct set.
         if with_sequence:
-            query += """
-            )
-            SELECT
+            select_cols = """
                 sm.ship_id,
                 sm.accession_tag,
                 sm.version_tag,
@@ -259,26 +181,18 @@ def fetch_ships(
                 sm.contigID,
                 sm.name,
                 sm.family,
-                sm.`order`,
+                sm."order",
                 sm.familyName,
                 sm.navis_name,
                 sm.haplotype_name,
                 sm.assembly_accession,
                 sm.type_ship,
-                s.sequence,
-                s.md5,
-                s.rev_comp_md5,
-                sm.captainID
-            FROM ships_with_metadata sm
-            LEFT JOIN ships s ON s.id = sm.ship_id
-            WHERE s.sequence IS NOT NULL"""
-
-            query += """
-            """
+                sm.sequence,
+                sm.md5,
+                sm.rev_comp_md5,
+                sm.captainID"""
         else:
-            query += """
-            )
-            SELECT
+            select_cols = """
                 sm.accession_tag,
                 sm.version_tag,
                 sm.accession_display,
@@ -291,17 +205,59 @@ def fetch_ships(
                 sm.contigID,
                 sm.name,
                 sm.family,
-                sm.`order`,
+                sm."order",
                 sm.familyName,
                 sm.navis_name,
                 sm.haplotype_name,
                 sm.assembly_accession,
                 sm.type_ship,
-                sm.captainID
-            FROM ships_with_metadata sm"""
+                sm.captainID"""
 
-            query += """
-            """
+        query = f"""
+        SELECT DISTINCT
+        {select_cols}
+        FROM ships_with_metadata sm
+        WHERE 1=1
+        """
+
+        if accessions:
+            formatted_values = [str(tag).strip("'\"") for tag in accessions]
+            quoted_sql = ", ".join(
+                "'" + str(v).replace("'", "''") + "'" for v in formatted_values
+            )
+            # Match base accession with or without version suffix
+            like_clauses = " OR ".join(
+                "sm.accession_tag LIKE '" + str(v).replace("'", "''") + ".%'"
+                for v in formatted_values
+            )
+            ship_like_clauses = " OR ".join(
+                "sm.ship_accession_tag LIKE '" + str(v).replace("'", "''") + ".%'"
+                for v in formatted_values
+            )
+
+            if accession_mode == "SSA":
+                query += " AND (sm.accession_tag IN ({}) OR ({}))".format(
+                    quoted_sql, like_clauses
+                )
+            elif accession_mode == "SSB":
+                query += " AND (sm.ship_accession_tag IN ({}) OR ({}))".format(
+                    quoted_sql, ship_like_clauses
+                )
+            elif accession_mode is None:
+                # Mixed or unknown: match either column (e.g. download with mixed SSA/SSB or null SSA)
+                query += " AND ((sm.accession_tag IN ({}) OR ({})) OR (sm.ship_accession_tag IN ({}) OR ({})))".format(
+                    quoted_sql,
+                    like_clauses,
+                    quoted_sql,
+                    ship_like_clauses,
+                )
+            else:
+                raise ValueError(f"Invalid accession mode: {accession_mode}")
+        if curated:
+            query += " AND sm.curated_status = 'curated'"
+
+        if with_sequence:
+            query += " AND sm.sequence IS NOT NULL"
 
         try:
             df = pd.read_sql_query(query, session.bind)
@@ -335,24 +291,10 @@ def fetch_ship_table(curated=True, with_sequence=False, with_gff_entries=False):
                 full_df = pd.DataFrame.from_dict(full_df["pandas_df"])
         else:
             try:
-                query = """
-                SELECT DISTINCT
-                    js.ship_id,
-                    js.source,
-                    js.curated_status,
-                    sa.ship_accession_tag,
-                    sa.ship_version_tag,
-                    sa.ship_accession_display,
-                    f.familyName,
-                    t.name,
-                    a.accession_tag, a.version_tag, a.accession_display
-                FROM joined_ships js
-                LEFT JOIN ship_accessions sa ON sa.ship_id = js.ship_id
-                LEFT JOIN taxonomy t ON js.tax_id = t.id
-                LEFT JOIN family_names f ON js.ship_family_id = f.id
-                LEFT JOIN accessions a ON js.accession_id = a.id
-                WHERE js.ship_id IS NOT NULL
-                """
+                # ship_table_view mirrors this narrower join (see
+                # alembic/versions/i2j3k4l5m6n7_*) — no features/genomes/
+                # navis/haplotype/captains, to avoid row fan-out.
+                query = "SELECT * FROM ship_table_view"
 
                 full_df = pd.read_sql_query(query, session.bind)
 
@@ -462,46 +404,22 @@ def fetch_captains(
         pd.DataFrame: DataFrame containing captain data
     """
 
-    # CTE: denormalized captains (joined_ships + display metadata). Not validation—just one place for the join.
-    query = """
-    WITH captains_with_metadata AS (
-        SELECT DISTINCT
-            sa.ship_accession_tag,
-            sa.ship_version_tag,
-            sa.ship_accession_display,
-            j.curated_status,
-            j.starshipID,
-            c.captainID as captain_id,
-            c."sequence",
-            n.navis_name,
-            h.haplotype_name,
-            c.captainID,
-            a.accession_tag,
-            a.version_tag,
-            a.accession_display
-        FROM joined_ships j
-        LEFT JOIN ship_accessions sa ON sa.ship_id = j.ship_id
-        LEFT JOIN taxonomy t ON j.tax_id = t.id
-        LEFT JOIN family_names f ON j.ship_family_id = f.id
-        LEFT JOIN navis_names n ON j.ship_navis_id = n.id
-        LEFT JOIN haplotype_names h ON j.ship_haplotype_id = h.id
-        LEFT JOIN genomes g ON j.genome_id = g.id
-        LEFT JOIN captains c ON j.captain_id = c.id
-        LEFT JOIN starship_features sf ON j.ship_id = sf.ship_id
-        LEFT JOIN accessions a ON j.accession_id = a.id
-        WHERE 1=1 AND j.ship_id IS NOT NULL
-    """
-
+    # captains_with_metadata is a real SQL view (see
+    # alembic/versions/i2j3k4l5m6n7_*) mirroring the join previously
+    # duplicated here as an inline CTE.
+    where_clauses = ["1=1"]
     if accessions:
-        query += " AND sa.ship_accession_tag IN ({})".format(
-            ",".join(f"'{tag}'" for tag in accessions)
+        where_clauses.append(
+            "cm.ship_accession_tag IN ({})".format(
+                ",".join(f"'{tag}'" for tag in accessions)
+            )
         )
     if curated:
-        query += " AND j.curated_status = 'curated'"
+        where_clauses.append("cm.curated_status = 'curated'")
 
     if with_sequence:
-        query += """
-        )
+        where_clauses.append("cm.captain_sequence IS NOT NULL")
+        query = """
         SELECT
             cm.ship_accession_tag,
             cm.version_tag,
@@ -513,22 +431,20 @@ def fetch_captains(
                 NULLIF(TRIM(COALESCE(CAST(cm.ship_accession_display AS TEXT), '')), ''),
                 NULLIF(TRIM(COALESCE(CAST(cm.ship_accession_tag AS TEXT), '')), ''),
                 NULLIF(TRIM(COALESCE(CAST(cm.starshipID AS TEXT), '')), ''),
-                'captain_' || CAST(cm.captain_id AS TEXT)
+                'captain_' || CAST(cm.captain_row_id AS TEXT)
             ) AS accession_display,
             cm.curated_status,
             cm.starshipID,
-            cm.captain_id,
-            cm.sequence,
+            cm.captainID as captain_id,
+            cm.captain_sequence as "sequence",
             cm.navis_name,
             cm.haplotype_name,
-            cm.captain_id as captain_id_col
+            cm.captainID as captain_id_col
         FROM captains_with_metadata cm
-        WHERE cm.sequence IS NOT NULL
-        """
+        WHERE """ + " AND ".join(where_clauses)
     else:
-        query += """
-        )
-        SELECT 
+        query = """
+        SELECT
             cm.accession_tag,
             cm.version_tag,
             cm.accession_display,
@@ -538,10 +454,9 @@ def fetch_captains(
             cm.starshipID,
             cm.captainID,
             cm.navis_name,
-            cm.haplotype_name,
-            cm.captainID
+            cm.haplotype_name
         FROM captains_with_metadata cm
-        """
+        WHERE """ + " AND ".join(where_clauses)
 
     with get_starbase_session() as session:
         try:

--- a/src/pages/synteny.py
+++ b/src/pages/synteny.py
@@ -847,7 +847,11 @@ def generate_synteny_data(n_clicks, selected_ships, color_by, label_field):
 
         clusters = []
         for ship_id in ship_ids:
-            ship_gff = [g for g in gff_data if g["ship_id"] == ship_id]
+            ship_gff = [
+                g
+                for g in gff_data
+                if g["ship_id"] == ship_id and g.get("type", "").lower() == "gene"
+            ]
 
             if not ship_gff:
                 continue

--- a/src/pages/wiki.py
+++ b/src/pages/wiki.py
@@ -39,6 +39,10 @@ from src.config.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Unresolved-species taxonomic qualifiers (NCBI convention) -- not real taxon
+# names, excluded from the taxa search autocomplete/filter.
+TAXA_PLACEHOLDER_VALUES = {"sp", "sp.", "spp", "spp.", "cf", "cf.", "aff", "aff."}
+
 dash.register_page(__name__)
 
 
@@ -822,15 +826,11 @@ def populate_search_components(meta_data):
         # Get taxonomy search data
         search_columns = [
             "name",
-            "subkingdom",
-            "phylum",
-            "subphylum",
             "class",
-            "subclass",
             "order",
-            "suborder",
             "family",
             "genus",
+            "species",
         ]
 
         # Collect all unique values across specified columns
@@ -841,6 +841,11 @@ def populate_search_components(meta_data):
                 # Get non-null values and add to set
                 values = df[col].dropna().astype(str).unique()
                 all_taxa_values.update(values)
+
+        # Drop unresolved-species placeholder qualifiers (e.g. "sp.", "cf.", "aff.") --
+        # not real taxa, and being short they'd otherwise dominate the top of the
+        # length-sorted autocomplete list.
+        all_taxa_values -= TAXA_PLACEHOLDER_VALUES
 
         # Convert to sorted list and format for Autocomplete
         # sort by length instead of alphabetically
@@ -943,15 +948,11 @@ def handle_taxa_and_family_search(
             # Define columns to search across
             taxa_search_columns = [
                 "name",
-                "subkingdom",
-                "phylum",
-                "subphylum",
                 "class",
-                "subclass",
                 "order",
-                "suborder",
                 "family",
                 "genus",
+                "species",
             ]
 
             # Create a mask for rows that contain the search value in any of the specified columns

--- a/src/pages/wiki.py
+++ b/src/pages/wiki.py
@@ -295,6 +295,22 @@ main_card = dmc.Paper(
                     limit=20,
                     style={"flex": 1, "minWidth": "12.5rem"},
                 ),
+                dmc.Autocomplete(
+                    id="group-accession-search",
+                    label="Group Accession (SSA)",
+                    placeholder="e.g. SSA000001",
+                    data=[],
+                    limit=20,
+                    style={"flex": 1, "minWidth": "12.5rem"},
+                ),
+                dmc.Autocomplete(
+                    id="ship-accession-search",
+                    label="Ship Accession (SSB)",
+                    placeholder="e.g. SSB000001",
+                    data=[],
+                    limit=20,
+                    style={"flex": 1, "minWidth": "12.5rem"},
+                ),
             ],
         ),
         dmc.Group(
@@ -789,6 +805,8 @@ def create_search_results(filtered_meta, cached_meta, curated, dereplicate):
     [
         Output("taxa-search", "data"),
         Output("family-search", "data"),
+        Output("group-accession-search", "data"),
+        Output("ship-accession-search", "data"),
     ],
     Input("meta-data", "data"),
     prevent_initial_call=False,  # Allow initial call to populate on page load
@@ -796,7 +814,7 @@ def create_search_results(filtered_meta, cached_meta, curated, dereplicate):
 @handle_callback_error
 def populate_search_components(meta_data):
     if not meta_data:
-        return [], []
+        return [], [], [], []
 
     try:
         df = pd.DataFrame(meta_data)
@@ -842,11 +860,36 @@ def populate_search_components(meta_data):
         else:
             family_search_data = []
 
-        return taxa_search_data, family_search_data
+        # Get group accession (SSA) search data
+        group_accession_search_data = []
+        if "accession_tag" in df.columns:
+            group_accession_values = df["accession_tag"].dropna().astype(str).unique()
+            group_accession_search_data = [
+                {"value": val, "label": val}
+                for val in sorted(group_accession_values)
+            ]
+
+        # Get ship accession (SSB) search data
+        ship_accession_search_data = []
+        if "ship_accession_tag" in df.columns:
+            ship_accession_values = (
+                df["ship_accession_tag"].dropna().astype(str).unique()
+            )
+            ship_accession_search_data = [
+                {"value": val, "label": val}
+                for val in sorted(ship_accession_values)
+            ]
+
+        return (
+            taxa_search_data,
+            family_search_data,
+            group_accession_search_data,
+            ship_accession_search_data,
+        )
 
     except Exception as e:
         logger.error(f"Error in populate_search_components: {str(e)}")
-        return [], []
+        return [], [], [], []
 
 
 @callback(
@@ -858,13 +901,21 @@ def populate_search_components(meta_data):
     [
         State("taxa-search", "value"),
         State("family-search", "value"),
+        State("group-accession-search", "value"),
+        State("ship-accession-search", "value"),
         State("meta-data", "data"),
     ],
     prevent_initial_call=True,
 )
 @handle_callback_error
 def handle_taxa_and_family_search(
-    search_clicks, reset_clicks, taxa_search_value, family_search_value, original_data
+    search_clicks,
+    reset_clicks,
+    taxa_search_value,
+    family_search_value,
+    group_accession_search_value,
+    ship_accession_search_value,
+    original_data,
 ):
     if not original_data:
         raise PreventUpdate
@@ -924,6 +975,22 @@ def handle_taxa_and_family_search(
                 filtered_df = filtered_df[
                     filtered_df["familyName"].astype(str).str.lower()
                     == family_search_value.lower()
+                ]
+
+        # Apply group accession (SSA) search if value is provided
+        if group_accession_search_value and group_accession_search_value.strip():
+            if "accession_tag" in filtered_df.columns:
+                filtered_df = filtered_df[
+                    filtered_df["accession_tag"].astype(str).str.lower()
+                    == group_accession_search_value.strip().lower()
+                ]
+
+        # Apply ship accession (SSB) search if value is provided
+        if ship_accession_search_value and ship_accession_search_value.strip():
+            if "ship_accession_tag" in filtered_df.columns:
+                filtered_df = filtered_df[
+                    filtered_df["ship_accession_tag"].astype(str).str.lower()
+                    == ship_accession_search_value.strip().lower()
                 ]
 
         # Return empty list if no results found, otherwise return the filtered data


### PR DESCRIPTION
# Summary

This PR migrates ship/accession metadata queries onto database views, adds soft-delete support with a foreign key on ship accessions, and improves search/filtering across the wiki and synteny pages.

## Database views & soft delete
- create views — adds a new Alembic migration introducing metadata views (i2j3k4l5m6n7_add_metadata_views.py).
- use views instead of sql queries — refactors sql_manager.py to query through the new views rather than raw SQL (net -85 lines).
- added new FK for ship_accessions and soft delete column in joined ships — new migration (...m6n7o8_add_ship_accession_fk_and_soft_delete.py) adding a FK on ship_accessions and an is_deleted column; all views now default to is_deleted = 0; adds a set_ship_deleted helper for future soft-delete use.
- database stats only shows is_deleted = 0 — filters deleted rows out of stats queries.
- wiki search should include genus — adds a taxonomy hierarchy migration (...6n7o8p9_add_taxonomy_hierarchy_to_ships_view.py) and updates wiki search so genus-level matches surface, while sp, sp., cf. entries are dropped from the top of results.
## Wiki page
- accession search bars on wiki page — adds dedicated accession search inputs to the wiki UI.
## Synteny viz
- only show gene features in viz — filters synteny plot to gene features only.