### PR TITLE
Lightweight modals, admin page add rows, md5sums for captain sequences

### DIFF
--- a/alembic/versions/l5m6n7o8p9q0_add_md5_and_length_to_captains.py
+++ b/alembic/versions/l5m6n7o8p9q0_add_md5_and_length_to_captains.py
@@ -1,0 +1,35 @@
+"""Add md5 and sequence_length to captains, matching ships table conventions
+
+Revision ID: l5m6n7o8p9q0
+Revises: k4l5m6n7o8p9
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "l5m6n7o8p9q0"
+down_revision: Union[str, None] = "k4l5m6n7o8p9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add md5 and sequence_length columns to captains (mirrors ships), plus an
+    index on md5 to make sequence-duplicate lookups cheap. Data backfill for
+    existing rows is handled separately by a cleanup script, not here."""
+
+    op.add_column("captains", sa.Column("md5", sa.Text(), nullable=True))
+    op.add_column("captains", sa.Column("sequence_length", sa.Integer(), nullable=True))
+    op.create_index("idx_captains_md5", "captains", ["md5"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_captains_md5", table_name="captains")
+    op.drop_column("captains", "sequence_length")
+    op.drop_column("captains", "md5")

--- a/assets/js/universal-modal.js
+++ b/assets/js/universal-modal.js
@@ -318,7 +318,7 @@ if (typeof window.UniversalModal === 'undefined') {
             this.init();
         }
 
-        document.getElementById('universal-modal-title').innerHTML = title;
+        document.getElementById('universal-modal-title').innerHTML = window.UniversalModal.escapeHtml(title);
         document.getElementById('universal-modal-content').innerHTML = content;
         this.modal.style.display = 'block';
 
@@ -335,9 +335,23 @@ if (typeof window.UniversalModal === 'undefined') {
         return v != null && v !== '' && String(v).trim() !== 'N/A';
     }
 
+    // Escape untrusted values before they are interpolated into innerHTML template strings.
+    static escapeHtml(v) {
+        if (v == null) return '';
+        return String(v).replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+        }[c]));
+    }
+
     // Static method to render modal content from structured data
     static renderAccessionModal(data) {
         let html = '';
+
+        const esc = (v) => this.escapeHtml(v);
 
         // Handle error case
         if (data.error) {
@@ -345,7 +359,7 @@ if (typeof window.UniversalModal === 'undefined') {
                 <div class="modal-container">
                     <div class="alert alert-red">
                         <div style="font-weight: 600; margin-bottom: 8px;">Error</div>
-                        <div>${data.error}</div>
+                        <div>${esc(data.error)}</div>
                     </div>
                 </div>
             `;
@@ -380,31 +394,31 @@ if (typeof window.UniversalModal === 'undefined') {
                             ${starshipSizeBp ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Size:</span>
-                                    <span class="modal-value">${starshipSizeBp} bp</span>
+                                    <span class="modal-value">${esc(starshipSizeBp)} bp</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.familyName) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Starship Family:</span>
-                                    <span class="modal-value">${data.familyName}</span>
+                                    <span class="modal-value">${esc(data.familyName)}</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.navis_name) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Starship Navis:</span>
-                                    <span class="modal-value">${data.navis_name}</span>
+                                    <span class="modal-value">${esc(data.navis_name)}</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.haplotype_name) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Haplotype:</span>
-                                    <span class="modal-value">${data.haplotype_name}</span>
+                                    <span class="modal-value">${esc(data.haplotype_name)}</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.genomes_present) && data.genomes_present > 1 ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Genomes Present:</span>
-                                    <span class="modal-badge badge-blue">${data.genomes_present}</span>
+                                    <span class="modal-badge badge-blue">${esc(data.genomes_present)}</span>
                                 </div>
                             ` : ''}
                         </div>
@@ -415,16 +429,16 @@ if (typeof window.UniversalModal === 'undefined') {
 
                             let genomeUrl = null;
                             let sequenceViewerUrl = null;
-                            if (hasAssemblyAccession && hasGenomeSource) {
+                            if (hasAssemblyAccession && hasGenomeSource && isValidAccession(genome.assembly_accession)) {
                                 if (source === 'jgi') {
-                                    genomeUrl = `https://mycocosm.jgi.doe.gov/${genome.assembly_accession}/${genome.assembly_accession}.home.html`;
+                                    genomeUrl = `https://mycocosm.jgi.doe.gov/${encodeURIComponent(genome.assembly_accession)}/${encodeURIComponent(genome.assembly_accession)}.home.html`;
                                 } else if (source === 'ncbi') {
-                                    genomeUrl = `https://www.ncbi.nlm.nih.gov/datasets/genome/${genome.assembly_accession}/`;
+                                    genomeUrl = `https://www.ncbi.nlm.nih.gov/datasets/genome/${encodeURIComponent(genome.assembly_accession)}/`;
                                 }
                                 if ((source === 'jgi' || source === 'ncbi') && hasValue(genome.contig_id) && isValidAccession(genome.contig_id) && hasValue(genome.element_position)) {
                                     const posMatch = (genome.element_position || '').match(/^(\d+)\s*-\s*(\d+)$/);
                                     if (posMatch) {
-                                        sequenceViewerUrl = `https://www.ncbi.nlm.nih.gov/projects/sviewer/?id=${genome.contig_id}&from=${posMatch[1]}&to=${posMatch[2]}`;
+                                        sequenceViewerUrl = `https://www.ncbi.nlm.nih.gov/projects/sviewer/?id=${encodeURIComponent(genome.contig_id)}&from=${posMatch[1]}&to=${posMatch[2]}`;
                                     }
                                 }
                             }
@@ -440,12 +454,12 @@ if (typeof window.UniversalModal === 'undefined') {
                             }
 
                             const sectionTitle = hasAssemblyAccession && hasGenomeSource
-                                ? `Genome: ${genome.assembly_accession}`
-                                : hasAssemblyAccession ? genome.assembly_accession
-                                : hasGenomeSource ? genome.genome_source
+                                ? `Genome: ${esc(genome.assembly_accession)}`
+                                : hasAssemblyAccession ? esc(genome.assembly_accession)
+                                : hasGenomeSource ? esc(genome.genome_source)
                                 : (data.genomes.length === 1 ? 'Genome' : `Genome ${i + 1}`);
                             const sectionTitleHtml = genomeUrl && hasAssemblyAccession && hasGenomeSource
-                                ? `Genome: <a href="${genomeUrl}" target="_blank" class="modal-link">${genome.assembly_accession}</a>`
+                                ? `Genome: <a href="${genomeUrl}" target="_blank" class="modal-link">${esc(genome.assembly_accession)}</a>`
                                 : sectionTitle;
 
                             return `
@@ -456,31 +470,31 @@ if (typeof window.UniversalModal === 'undefined') {
                                     ${hasValue(genome.assembly_accession) ? `
                                         <div class="modal-row">
                                             <span class="modal-label">Assembly Accession:</span>
-                                            <span class="modal-value">${genomeUrl ? `<a href="${genomeUrl}" target="_blank" class="modal-link">${genome.assembly_accession}</a>` : genome.assembly_accession}</span>
+                                            <span class="modal-value">${genomeUrl ? `<a href="${genomeUrl}" target="_blank" class="modal-link">${esc(genome.assembly_accession)}</a>` : esc(genome.assembly_accession)}</span>
                                         </div>
                                     ` : ''}
                                     ${hasValue(genome.genome_source) ? `
                                         <div class="modal-row">
                                             <span class="modal-label">Genome Source:</span>
-                                            <span class="modal-value">${genome.genome_source}</span>
+                                            <span class="modal-value">${esc(genome.genome_source)}</span>
                                         </div>
                                     ` : ''}
                                     ${hasValue(genome.contig_id) ? `
                                         <div class="modal-row">
                                             <span class="modal-label">Contig ID:</span>
-                                            <span class="modal-value">${sequenceViewerUrl ? `<a href="${sequenceViewerUrl}" target="_blank" class="modal-link">${genome.contig_id}</a>` : genome.contig_id}</span>
+                                            <span class="modal-value">${sequenceViewerUrl ? `<a href="${sequenceViewerUrl}" target="_blank" class="modal-link">${esc(genome.contig_id)}</a>` : esc(genome.contig_id)}</span>
                                         </div>
                                     ` : ''}
                                     ${hasValue(genome.element_position) ? `
                                         <div class="modal-row">
                                             <span class="modal-label">Element Position:</span>
-                                            <span class="modal-value">${genome.element_position}</span>
+                                            <span class="modal-value">${esc(genome.element_position)}</span>
                                         </div>
                                     ` : ''}
                                     ${!starshipSizeBp && hasValue(genome.element_length) ? `
                                         <div class="modal-row">
                                             <span class="modal-label">Size:</span>
-                                            <span class="modal-value">${genome.element_length} bp</span>
+                                            <span class="modal-value">${esc(genome.element_length)} bp</span>
                                         </div>
                                     ` : ''}
                                     </div>
@@ -503,26 +517,26 @@ if (typeof window.UniversalModal === 'undefined') {
                             ${hasValue(data.order) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Order:</span>
-                                    <span class="modal-value">${data.order}</span>
+                                    <span class="modal-value">${esc(data.order)}</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.family) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Family:</span>
-                                    <span class="modal-value">${data.family}</span>
+                                    <span class="modal-value">${esc(data.family)}</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.species_name) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Species:</span>
-                                    <span class="modal-value">${data.species_name}</span>
+                                    <span class="modal-value">${esc(data.species_name)}</span>
                                 </div>
                             ` : ''}
                             ${hasValue(data.tax_id) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">NCBI Taxonomy ID:</span>
                                     <span class="modal-value">
-                                        <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=${data.tax_id}" target="_blank" class="modal-link">${data.tax_id}</a>
+                                        <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=${encodeURIComponent(data.tax_id)}" target="_blank" class="modal-link">${esc(data.tax_id)}</a>
                                     </span>
                                 </div>
                             ` : ''}
@@ -542,14 +556,14 @@ if (typeof window.UniversalModal === 'undefined') {
                             ${hasValue(data.curated_status) ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Curation Status:</span>
-                                    <span class="modal-badge badge-${data.curated_status === 'curated' ? 'green' : 'yellow'}">${data.curated_status}</span>
+                                    <span class="modal-badge badge-${data.curated_status === 'curated' ? 'green' : 'yellow'}">${esc(data.curated_status)}</span>
                                 </div>
                             ` : ''}
                             ${data.quality_tags && data.quality_tags.length > 0 ? `
                                 <div class="modal-row">
                                     <span class="modal-label">Quality Tags:</span>
                                     <div class="quality-tags">
-                                        ${data.quality_tags.map(tag => `<span class="modal-badge badge-yellow">${tag}</span>`).join('')}
+                                        ${data.quality_tags.map(tag => `<span class="modal-badge badge-yellow">${esc(tag)}</span>`).join('')}
                                     </div>
                                 </div>
                             ` : ''}
@@ -569,13 +583,15 @@ if (typeof window.UniversalModal === 'undefined') {
     static renderGroupAccessionModal(data) {
         let html = '';
 
+        const esc = (v) => this.escapeHtml(v);
+
         // Handle error case
         if (data.error) {
             return `
                 <div class="modal-container">
                     <div class="alert alert-red">
                         <div style="font-weight: 600; margin-bottom: 8px;">Error</div>
-                        <div>${data.error}</div>
+                        <div>${esc(data.error)}</div>
                     </div>
                 </div>
             `;
@@ -589,16 +605,16 @@ if (typeof window.UniversalModal === 'undefined') {
         html += '<div class="section-content"><div class="modal-grid">';
 
         if (hasValue(data.familyName)) {
-            html += `<div class="modal-row"><span class="modal-label">Starship Family:</span><span class="modal-value">${data.familyName}</span></div>`;
+            html += `<div class="modal-row"><span class="modal-label">Starship Family:</span><span class="modal-value">${esc(data.familyName)}</span></div>`;
         }
         if (hasValue(data.genomes_present)) {
-            html += `<div class="modal-row"><span class="modal-label">Genomes Present:</span><span class="modal-badge badge-blue">${data.genomes_present}</span></div>`;
+            html += `<div class="modal-row"><span class="modal-label">Genomes Present:</span><span class="modal-badge badge-blue">${esc(data.genomes_present)}</span></div>`;
         }
         if (hasValue(data.navis_name)) {
-            html += `<div class="modal-row"><span class="modal-label">Starship Navis:</span><span class="modal-value">${data.navis_name}</span></div>`;
+            html += `<div class="modal-row"><span class="modal-label">Starship Navis:</span><span class="modal-value">${esc(data.navis_name)}</span></div>`;
         }
         if (hasValue(data.haplotype_name)) {
-            html += `<div class="modal-row"><span class="modal-label">Haplotype:</span><span class="modal-value">${data.haplotype_name}</span></div>`;
+            html += `<div class="modal-row"><span class="modal-label">Haplotype:</span><span class="modal-value">${esc(data.haplotype_name)}</span></div>`;
         }
 
         html += '</div></div></div></div>';

--- a/src/components/callbacks.py
+++ b/src/components/callbacks.py
@@ -1,4 +1,4 @@
-from dash import html, Output, Input, State, callback, no_update, callback_context
+from dash import Output, Input, State, callback, callback_context
 from dash.exceptions import PreventUpdate
 import dash_mantine_components as dmc
 import functools
@@ -49,7 +49,33 @@ def handle_callback_error(callback_func):
     return wrapper
 
 
-def create_modal_callback(table_id, modal_id, content_id, title_id, column_check=None):
+def _extract_accession(raw_value, prefix):
+    """Pull the accession token (e.g. SSB0001) out of a cell value that may be
+    bracket-wrapped or path-like (e.g. '[SSB0001]', 'some/path/SSB0001')."""
+    parts = [p.strip() for p in str(raw_value).strip("[]").split("/") if p.strip()]
+    match = next((p for p in parts if p.upper().startswith(prefix)), None)
+    if match:
+        return match
+    return parts[-1] if parts else None
+
+
+def create_modal_callback(
+    table_id,
+    modal_id,
+    content_id,
+    title_id,
+    ship_cols=("ship_accession_tag", "ship_accession_display"),
+    group_cols=("accession_tag", "accession_display"),
+):
+    """Open a native dmc.Modal populated from the ship/group accession data
+    when a user clicks an accession cell in an AG Grid or Dash DataTable."""
+    from src.components.data import (
+        create_ship_accession_modal_data,
+        create_accession_modal_data,
+        render_ship_accession_modal,
+        render_group_accession_modal,
+    )
+
     @callback(
         Output(modal_id, "opened"),
         Output(content_id, "children"),
@@ -66,59 +92,53 @@ def create_modal_callback(table_id, modal_id, content_id, title_id, column_check
         prevent_initial_call=True,
     )
     def toggle_modal(cell_clicked, active_cell, table_data, page_current, page_size):
+        ctx = callback_context
+        if not ctx.triggered or not (cell_clicked or active_cell):
+            raise PreventUpdate
+
+        triggered_id = ctx.triggered[0]["prop_id"]
+        col_id = None
+        value = None
+
+        if f"{table_id}.cellClicked" in triggered_id and cell_clicked:
+            col_id = cell_clicked.get("colId")
+            value = cell_clicked.get("value")
+        elif f"{table_id}.active_cell" in triggered_id and active_cell:
+            col_id = active_cell.get("column_id")
+            row_idx = (page_current or 0) * (page_size or 0) + active_cell.get("row", 0)
+            if table_data and row_idx < len(table_data):
+                value = table_data[row_idx].get(col_id)
+
+        if col_id is None or not value:
+            raise PreventUpdate
+
+        if col_id in ship_cols:
+            prefix = "SSB"
+            fetch_data, render_content = create_ship_accession_modal_data, render_ship_accession_modal
+        elif col_id in group_cols:
+            prefix = "SSA"
+            fetch_data, render_content = create_accession_modal_data, render_group_accession_modal
+        else:
+            raise PreventUpdate
+
+        accession = _extract_accession(value, prefix)
+        if not accession:
+            raise PreventUpdate
+
         try:
-            ctx = callback_context
-            triggered_id = ctx.triggered[0]["prop_id"]
-
-            if not (cell_clicked or active_cell):
-                return False, no_update, no_update
-
-            accession = None
-            if f"{table_id}.cellClicked" in triggered_id and cell_clicked:
-                # AG Grid format - handle both accession_tag and accession_display
-                if cell_clicked["colId"] in [
-                    "ship_accession_tag",
-                    "ship_accession_display",
-                ]:
-                    accession = str(cell_clicked["value"])
-            elif f"{table_id}.active_cell" in triggered_id and active_cell:
-                # Dash DataTable format - handle both accession_tag and accession_display
-                if active_cell["column_id"] in [
-                    "ship_accession_tag",
-                    "ship_accession_display",
-                ]:
-                    # Calculate the actual row index based on pagination
-                    actual_row_idx = (page_current or 0) * page_size + active_cell[
-                        "row"
-                    ]
-                    if table_data and actual_row_idx < len(table_data):
-                        accession = str(
-                            table_data[actual_row_idx][active_cell["column_id"]]
-                        )
-
-            if accession:
-                # Clean and standardize the accession tag
-                accession = accession.strip("[]").split("/")[-1].strip()
-                logger.debug(f"Looking for accession in cache: {accession}")
-
-                # Instead of opening a Dash modal, trigger the universal modal via JavaScript
-                return (
-                    False,  # Don't open the Dash modal
-                    no_update,
-                    no_update,
-                )
-
-            return False, no_update, no_update
+            data = fetch_data(accession)
+            return True, render_content(data), data.get("title", accession)
         except Exception as e:
-            logger.error(f"Error in toggle_modal: {str(e)}")
+            logger.error(f"Error building accession modal for {accession}: {str(e)}")
             logger.error(traceback.format_exc())
-            error_content = html.Div(
-                [
-                    html.P("Error loading modal content"),
-                    html.P(f"Details: {str(e)}"),
-                ]
+            return (
+                True,
+                dmc.Alert(
+                    f"Error loading details for {accession}.",
+                    color="red",
+                    variant="light",
+                ),
+                "Error",
             )
-            error_title = dmc.Title("Error", order=3)
-            return True, error_content, error_title
 
     return toggle_modal

--- a/src/components/data.py
+++ b/src/components/data.py
@@ -1,5 +1,10 @@
+import re
 import traceback
+from urllib.parse import quote
+
 import pandas as pd
+import dash_mantine_components as dmc
+from dash import html
 
 from src.utils.seq_utils import extract_accession, clean_contigIDs
 from src.database.sql_manager import (
@@ -264,3 +269,230 @@ def create_accession_modal_data(accession):
         logger.error(f"Error in create_accession_modal_data: {str(e)}")
         logger.error(traceback.format_exc())
         raise
+
+
+# --- Native dmc.Modal rendering (replaces the vanilla-JS universal-modal renderers) ---
+
+_ACCESSION_RE = re.compile(r"^[A-Za-z]{2,}_?\d{6,}(\.\d+)?$", re.IGNORECASE)
+_POSITION_RE = re.compile(r"^(\d+)\s*-\s*(\d+)$")
+
+
+def _has_value(v):
+    return v is not None and v != "" and str(v).strip().upper() != "N/A"
+
+
+def _is_valid_accession(value):
+    return bool(value) and isinstance(value, str) and bool(_ACCESSION_RE.match(value.strip()))
+
+
+def _genome_urls(genome):
+    """Mirror the URL-construction logic from universal-modal.js's renderAccessionModal."""
+    assembly = genome.get("assembly_accession")
+    source = (genome.get("genome_source") or "").lower()
+    contig_id = genome.get("contig_id")
+    position = genome.get("element_position")
+
+    genome_url = None
+    sequence_viewer_url = None
+
+    if _has_value(assembly) and _has_value(source) and _is_valid_accession(assembly):
+        if source == "jgi":
+            genome_url = f"https://mycocosm.jgi.doe.gov/{quote(assembly)}/{quote(assembly)}.home.html"
+        elif source == "ncbi":
+            genome_url = f"https://www.ncbi.nlm.nih.gov/datasets/genome/{quote(assembly)}/"
+
+        if (
+            source in ("jgi", "ncbi")
+            and _has_value(contig_id)
+            and _is_valid_accession(contig_id)
+            and _has_value(position)
+        ):
+            match = _POSITION_RE.match(position)
+            if match:
+                sequence_viewer_url = (
+                    "https://www.ncbi.nlm.nih.gov/projects/sviewer/"
+                    f"?id={quote(contig_id)}&from={match.group(1)}&to={match.group(2)}"
+                )
+
+    return genome_url, sequence_viewer_url
+
+
+def _modal_row(label, value):
+    return dmc.Group(
+        [
+            dmc.Text(label, fw=600, size="sm", c="dimmed"),
+            value if hasattr(value, "to_plotly_json") else dmc.Text(str(value), size="sm"),
+        ],
+        justify="space-between",
+        wrap="nowrap",
+        gap="md",
+    )
+
+
+def _modal_section(title, children):
+    return dmc.Paper(
+        children=[
+            dmc.Text(title, fw=700, size="lg", ta="center", mb="md"),
+            dmc.Stack(children, gap="xs"),
+        ],
+        p="lg",
+        radius="md",
+        withBorder=True,
+    )
+
+
+def render_ship_accession_modal(data):
+    """Build the dmc content for a ship-accession modal from create_ship_accession_modal_data()'s output."""
+    if data.get("error"):
+        return dmc.Alert(data["error"], title="Error", color="red", variant="light")
+
+    genomes = data.get("genomes") or []
+    starship_size_bp = None
+    if len(genomes) == 1 and _has_value(genomes[0].get("element_length")):
+        starship_size_bp = str(genomes[0]["element_length"])
+
+    info_rows = []
+    if starship_size_bp:
+        info_rows.append(_modal_row("Size", f"{starship_size_bp} bp"))
+    if _has_value(data.get("familyName")):
+        info_rows.append(_modal_row("Starship Family", data["familyName"]))
+    if _has_value(data.get("navis_name")):
+        info_rows.append(_modal_row("Starship Navis", data["navis_name"]))
+    if _has_value(data.get("haplotype_name")):
+        info_rows.append(_modal_row("Haplotype", data["haplotype_name"]))
+    genomes_present = data.get("genomes_present")
+    if _has_value(genomes_present) and int(genomes_present) > 1:
+        info_rows.append(
+            _modal_row("Genomes Present", dmc.Badge(genomes_present, color="blue", variant="light"))
+        )
+
+    genome_sections = []
+    for i, genome in enumerate(genomes):
+        assembly = genome.get("assembly_accession")
+        source = genome.get("genome_source")
+        contig_id = genome.get("contig_id")
+        position = genome.get("element_position")
+        length = genome.get("element_length")
+
+        has_content = any(_has_value(v) for v in (assembly, source, contig_id, position)) or (
+            not starship_size_bp and _has_value(length)
+        )
+        if not has_content:
+            continue
+
+        genome_url, sequence_viewer_url = _genome_urls(genome)
+
+        if _has_value(assembly) and _has_value(source):
+            section_title = ["Genome: ", dmc.Anchor(assembly, href=genome_url, target="_blank")] if genome_url else f"Genome: {assembly}"
+        elif _has_value(assembly):
+            section_title = assembly
+        elif _has_value(source):
+            section_title = source
+        else:
+            section_title = "Genome" if len(genomes) == 1 else f"Genome {i + 1}"
+
+        rows = []
+        if _has_value(assembly):
+            value = dmc.Anchor(assembly, href=genome_url, target="_blank") if genome_url else assembly
+            rows.append(_modal_row("Assembly Accession", value))
+        if _has_value(source):
+            rows.append(_modal_row("Genome Source", source))
+        if _has_value(contig_id):
+            value = dmc.Anchor(contig_id, href=sequence_viewer_url, target="_blank") if sequence_viewer_url else contig_id
+            rows.append(_modal_row("Contig ID", value))
+        if _has_value(position):
+            rows.append(_modal_row("Element Position", position))
+        if not starship_size_bp and _has_value(length):
+            rows.append(_modal_row("Size", f"{length} bp"))
+
+        genome_sections.append(
+            dmc.Paper(
+                children=[
+                    dmc.Text(section_title, fw=700, size="md", ta="center", mb="sm"),
+                    dmc.Stack(rows, gap="xs"),
+                ],
+                p="md",
+                radius="md",
+                withBorder=True,
+                mt="md",
+            )
+        )
+
+    sections = []
+    if info_rows or genome_sections:
+        sections.append(
+            _modal_section(
+                "Starship Information",
+                (info_rows if info_rows else []) + genome_sections,
+            )
+        )
+
+    taxonomy_rows = []
+    if _has_value(data.get("order")):
+        taxonomy_rows.append(_modal_row("Order", data["order"]))
+    if _has_value(data.get("family")):
+        taxonomy_rows.append(_modal_row("Family", data["family"]))
+    if _has_value(data.get("species_name")):
+        taxonomy_rows.append(_modal_row("Species", data["species_name"]))
+    if _has_value(data.get("tax_id")):
+        taxonomy_rows.append(
+            _modal_row(
+                "NCBI Taxonomy ID",
+                dmc.Anchor(
+                    str(data["tax_id"]),
+                    href=f"https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id={quote(str(data['tax_id']))}",
+                    target="_blank",
+                ),
+            )
+        )
+    if taxonomy_rows:
+        sections.append(_modal_section("Taxonomy", taxonomy_rows))
+
+    quality_rows = []
+    if _has_value(data.get("curated_status")):
+        color = "green" if data["curated_status"] == "curated" else "yellow"
+        quality_rows.append(
+            _modal_row("Curation Status", dmc.Badge(data["curated_status"], color=color, variant="light"))
+        )
+    quality_tags = data.get("quality_tags") or []
+    if quality_tags:
+        quality_rows.append(
+            _modal_row(
+                "Quality Tags",
+                dmc.Group(
+                    [dmc.Badge(tag, color="yellow", variant="light") for tag in quality_tags],
+                    gap="xs",
+                    justify="flex-end",
+                ),
+            )
+        )
+    if quality_rows:
+        sections.append(_modal_section("Data Quality", quality_rows))
+
+    if not sections:
+        return dmc.Text("No details available for this accession.", c="dimmed", ta="center")
+
+    return dmc.Stack(sections, gap="md")
+
+
+def render_group_accession_modal(data):
+    """Build the dmc content for a group-accession (SSA) modal from create_accession_modal_data()'s output."""
+    if data.get("error"):
+        return dmc.Alert(data["error"], title="Error", color="red", variant="light")
+
+    rows = []
+    if _has_value(data.get("familyName")):
+        rows.append(_modal_row("Starship Family", data["familyName"]))
+    if _has_value(data.get("genomes_present")):
+        rows.append(
+            _modal_row("Genomes Present", dmc.Badge(data["genomes_present"], color="blue", variant="light"))
+        )
+    if _has_value(data.get("navis_name")):
+        rows.append(_modal_row("Starship Navis", data["navis_name"]))
+    if _has_value(data.get("haplotype_name")):
+        rows.append(_modal_row("Haplotype", data["haplotype_name"]))
+
+    if not rows:
+        return dmc.Text("No details available for this accession.", c="dimmed", ta="center")
+
+    return _modal_section("Group Information", rows)

--- a/src/config/cache.py
+++ b/src/config/cache.py
@@ -28,6 +28,18 @@ cache = Cache(
 )
 
 
+def invalidate_meta_and_ship_cache():
+    """Clear cached query results after a bulk DB write (e.g. cleanup/fill scripts).
+
+    Safe to call outside a Flask app context (standalone maintenance scripts) —
+    cache.clear() failures there are non-fatal, so we log and move on.
+    """
+    try:
+        cache.clear()
+    except Exception as e:
+        logger.warning(f"Cache invalidation skipped: {e}")
+
+
 def cleanup_old_cache(max_age_days=None):
     """Optional cache cleanup for persistent database data.
 

--- a/src/database/models/schema.py
+++ b/src/database/models/schema.py
@@ -76,6 +76,8 @@ class Captains(Base):
     id = Column(Integer, primary_key=True)
     captainID = Column(String, unique=True)
     sequence = Column(String)
+    md5 = Column(String)
+    sequence_length = Column(Integer)
     ship_id = Column(Integer, ForeignKey("ships.id"))
     reviewed = Column(String)
     evidence = Column(String)

--- a/src/pages/admin.py
+++ b/src/pages/admin.py
@@ -342,6 +342,47 @@ def _bump_version(version_str, bump_type):
     return version_str
 
 
+def _do_insert(table_key, col_values):
+    """Run a whitelisted INSERT for a new row. Returns (success, error, new_id)."""
+    allowed = EDITABLE_COLS.get(table_key, set())
+    config = TABLE_CONFIG[table_key]
+
+    cols = [c for c in col_values if c in allowed and col_values[c] not in (None, "")]
+    if not cols:
+        return False, "No editable field was filled in for the new row.", None
+
+    values = {}
+    for c in cols:
+        v = col_values[c]
+        if c in BOOLEAN_COLS:
+            v = 1 if str(v).lower() in ("true", "1", "yes") else 0
+        values[c] = v
+
+    col_refs = ", ".join(_sql_col_ref(c) for c in cols)
+    placeholders = ", ".join(f":{c}" for c in cols)
+    sql = text(
+        f"INSERT INTO {config['sql_table']} ({col_refs}) VALUES ({placeholders})"
+    )
+
+    try:
+        ctx = (
+            get_starbase_session
+            if config["db"] == "starbase"
+            else get_submissions_session
+        )
+        with ctx() as session:
+            result = session.execute(sql, values)
+            session.commit()
+            new_id = result.lastrowid
+        logger.info(
+            "admin INSERT %s: %r (id=%s)", config["sql_table"], values, new_id
+        )
+        return True, None, new_id
+    except Exception as exc:
+        logger.error("admin INSERT error (%s): %s", table_key, exc)
+        return False, str(exc), None
+
+
 def _do_update(table_key, row_id, col_id, new_value):
     """Run a whitelisted UPDATE. Returns (success: bool, error: str|None)."""
     allowed = EDITABLE_COLS.get(table_key, set())
@@ -1318,6 +1359,7 @@ def _overlay_job_changes_on_rowdata(table_key, changes):
     rows = _refetch_rowdata(table_key)
     if rows is no_update:
         return no_update
+    assert isinstance(rows, list)
     table_changes = [c for c in changes if c.get("table") == table_key]
     if not table_changes:
         return no_update
@@ -1762,6 +1804,13 @@ def _build_admin_layout():
                         dmc.Group(
                             [
                                 dmc.Button(
+                                    "Add row",
+                                    id="admin-add-row-btn",
+                                    variant="light",
+                                    color="blue",
+                                    size="sm",
+                                ),
+                                dmc.Button(
                                     "Discard",
                                     id="admin-discard-btn",
                                     variant="subtle",
@@ -1789,9 +1838,10 @@ def _build_admin_layout():
                 withBorder=True,
                 style={"borderColor": "var(--mantine-color-blue-3)"},
             ),
-            dbc.Tabs(
-                [
-                    dbc.Tab(
+            dbc.Tabs(  # pyright: ignore[reportCallIssue]
+                id="admin-tabs",
+                children=[
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             js_df,
                             "admin-joined-ships-grid",
@@ -1800,7 +1850,7 @@ def _build_admin_layout():
                         label=f"Starships ({len(js_df):,})",
                         tab_id="joined_ships",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         html.Div(
                             [
                                 dmc.Group(
@@ -1847,7 +1897,7 @@ def _build_admin_layout():
                         label=f"Submissions ({len(sub_df):,})",
                         tab_id="submissions",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             tax_df,
                             "admin-taxonomy-grid",
@@ -1856,7 +1906,7 @@ def _build_admin_layout():
                         label=f"Taxonomy ({len(tax_df):,})",
                         tab_id="taxonomy",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             pap_df,
                             "admin-papers-grid",
@@ -1865,7 +1915,7 @@ def _build_admin_layout():
                         label=f"Papers ({len(pap_df):,})",
                         tab_id="papers",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             fam_df,
                             "admin-family-names-grid",
@@ -1874,7 +1924,7 @@ def _build_admin_layout():
                         label=f"Families ({len(fam_df):,})",
                         tab_id="family_names",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             nav_df,
                             "admin-navis-names-grid",
@@ -1883,7 +1933,7 @@ def _build_admin_layout():
                         label=f"Navis ({len(nav_df):,})",
                         tab_id="navis_names",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             hap_df,
                             "admin-haplotype-names-grid",
@@ -1892,7 +1942,7 @@ def _build_admin_layout():
                         label=f"Haplotypes ({len(hap_df):,})",
                         tab_id="haplotype_names",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             acc_df,
                             "admin-accessions-grid",
@@ -1901,7 +1951,7 @@ def _build_admin_layout():
                         label=f"Accessions ({len(acc_df):,})",
                         tab_id="accessions",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             sacc_df,
                             "admin-ship-accessions-grid",
@@ -1910,7 +1960,7 @@ def _build_admin_layout():
                         label=f"Ship Accessions ({len(sacc_df):,})",
                         tab_id="ship_accessions",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _make_grid(
                             gen_df,
                             "admin-genomes-grid",
@@ -1919,7 +1969,7 @@ def _build_admin_layout():
                         label=f"Genomes ({len(gen_df):,})",
                         tab_id="genomes",
                     ),
-                    dbc.Tab(
+                    dbc.Tab(  # pyright: ignore[reportCallIssue]
                         _build_jobs_tab(),
                         label="Jobs",
                         tab_id="jobs",
@@ -2222,6 +2272,59 @@ for _tk, _gid in GRID_IDS.items():
     )
 
 # ---------------------------------------------------------------------------
+# Clientside callbacks — "Add row" button inserts a blank editable row into
+# whichever grid is on the active tab, and stages a __new_row__ marker so
+# save_all_pending knows to INSERT rather than UPDATE for that row_id.
+# ---------------------------------------------------------------------------
+
+_ADD_ROW_JS = """
+function(n, activeTab, rowData) {{
+    if (!n || activeTab !== "{tk}") return window.dash_clientside.no_update;
+    var tempId = -n;
+    var editableCols = {editable_cols_json};
+    var newRow = {{id: tempId, _dirty: 'new'}};
+    for (var i = 0; i < editableCols.length; i++) {{ newRow[editableCols[i]] = ''; }}
+    var rd = (rowData || []).slice();
+    rd.unshift(newRow);
+    return rd;
+}}
+"""
+
+for _tk, _gid in GRID_IDS.items():
+    clientside_callback(
+        _ADD_ROW_JS.format(
+            tk=_tk, editable_cols_json=list(EDITABLE_COLS.get(_tk, set()))
+        ),
+        Output(_gid, "rowData", allow_duplicate=True),
+        Input("admin-add-row-btn", "n_clicks"),
+        State("admin-tabs", "active_tab"),
+        State(_gid, "rowData"),
+        prevent_initial_call=True,
+    )
+
+# tempId must match the -n_clicks value used above so the marker's row_id
+# lines up with the blank row's id for whichever grid actually added one.
+clientside_callback(
+    """
+    function(n, activeTab, pending) {
+        if (!n || !activeTab) return window.dash_clientside.no_update;
+        var tempId = -n;
+        var p = JSON.parse(JSON.stringify(pending || []));
+        p.push({
+            table: activeTab, row_id: tempId, col_id: "__new_row__",
+            old_value: null, new_value: {}, source: 'manual'
+        });
+        return p;
+    }
+    """,
+    Output("admin-pending-changes", "data", allow_duplicate=True),
+    Input("admin-add-row-btn", "n_clicks"),
+    State("admin-tabs", "active_tab"),
+    State("admin-pending-changes", "data"),
+    prevent_initial_call=True,
+)
+
+# ---------------------------------------------------------------------------
 # Clientside callback — relay selectedRows into static-layout store
 # (avoids refErr for State("admin-submissions-grid", "selectedRows") in Python
 # callbacks that are validated against the initial layout before auth)
@@ -2314,7 +2417,28 @@ def save_all_pending(n_clicks, pending):
 
     logger.info("save_all_pending: %d change(s): %s", len(pending), pending)
     errors, successes = [], []
-    for ch in pending:
+
+    new_row_markers = [ch for ch in pending if ch.get("col_id") == "__new_row__"]
+    new_row_keys = {(m["table"], m["row_id"]) for m in new_row_markers}
+    updates = [
+        ch
+        for ch in pending
+        if (ch["table"], ch["row_id"]) not in new_row_keys
+    ]
+
+    for table, row_id in new_row_keys:
+        col_values = {
+            ch["col_id"]: ch.get("new_value")
+            for ch in pending
+            if ch["table"] == table
+            and ch["row_id"] == row_id
+            and ch["col_id"] != "__new_row__"
+        }
+        ok, err, new_id = _do_insert(table, col_values)
+        marker = {"table": table, "row_id": row_id, "col_id": "__new_row__"}
+        (successes if ok else errors).append((marker, err))
+
+    for ch in updates:
         ok, err = _do_update(
             ch["table"], ch["row_id"], ch["col_id"], ch.get("new_value")
         )

--- a/src/pages/wiki.py
+++ b/src/pages/wiki.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import dash
-from dash import dcc, html, callback, clientside_callback
+from dash import dcc, html, callback
 from dash.dependencies import Output, Input, State
 from dash.exceptions import PreventUpdate
 
@@ -34,7 +34,7 @@ from src.components.ui import (
     _i,
     _lt,
 )
-from src.components.callbacks import handle_callback_error
+from src.components.callbacks import handle_callback_error, create_modal_callback
 from src.config.logging import get_logger
 
 logger = get_logger(__name__)
@@ -536,7 +536,14 @@ info_table_paper = dmc.Paper(
                         table_columns=table_columns,
                     ),
                 ),
-                html.Div(id="dummy-output", style={"display": "none"}),
+                dmc.Modal(
+                    id="accession-modal",
+                    opened=False,
+                    size="lg",
+                    centered=True,
+                    title=html.Div(id="accession-modal-title"),
+                    children=html.Div(id="accession-modal-content"),
+                ),
             ],
         ),
     ],
@@ -1295,72 +1302,11 @@ def update_download_selected_button(selected_rows):
     return not selected_rows or len(selected_rows) == 0
 
 
-# Add clientside callback to handle accession modal clicks
-clientside_callback(
-    """
-    function(cellClicked, activeCell, tableData, pageCurrent, pageSize) {
-        if (!cellClicked && !activeCell) {
-            return window.dash_clientside.no_update;
-        }
-
-        let accession = null;
-        let isShipColumn = false;
-        let isGroupColumn = false;
-
-        const shipCols = ['ship_accession_tag', 'ship_accession_display'];
-        const groupCols = ['accession_tag', 'accession_display'];
-
-        // Handle AG Grid cell clicks
-        if (cellClicked) {
-            if (shipCols.includes(cellClicked.colId)) {
-                accession = cellClicked.value;
-                isShipColumn = true;
-            } else if (groupCols.includes(cellClicked.colId)) {
-                accession = cellClicked.value;
-                isGroupColumn = true;
-            }
-        }
-        // Handle DataTable active cell
-        else if (activeCell) {
-            const actualRowIdx = (pageCurrent || 0) * pageSize + activeCell.row;
-            if (tableData && actualRowIdx < tableData.length) {
-                if (shipCols.includes(activeCell.column_id)) {
-                    accession = tableData[actualRowIdx][activeCell.column_id];
-                    isShipColumn = true;
-                } else if (groupCols.includes(activeCell.column_id)) {
-                    accession = tableData[actualRowIdx][activeCell.column_id];
-                    isGroupColumn = true;
-                }
-            }
-        }
-
-        if (accession) {
-            let parts = accession.toString().trim().split('/').map(s => s.trim()).filter(Boolean);
-            if (isShipColumn) {
-                let ssbPart = parts.find(p => p.startsWith('SSB'));
-                accession = ssbPart || (parts.length > 0 ? parts[parts.length - 1] : accession);
-                showShipAccessionModal(accession);
-            } else if (isGroupColumn) {
-                let ssaPart = parts.find(p => p.startsWith('SSA'));
-                accession = ssaPart || (parts.length > 0 ? parts[parts.length - 1] : accession);
-                showGroupAccessionModal(accession);
-            }
-        }
-
-        return window.dash_clientside.no_update;
-    }
-    """,
-    Output(
-        "dummy-output", "children"
-    ),  # Dummy output since we don't need to update any Dash components
-    [
-        Input("dl-table", "cellClicked"),
-        Input("dl-table", "active_cell"),
-    ],
-    [
-        State("dl-table", "derived_virtual_data"),
-        State("dl-table", "page_current"),
-        State("dl-table", "page_size"),
-    ],
-    prevent_initial_call=True,
+# Open a native dmc.Modal (accession-modal, defined in the layout above) when a
+# user clicks a ship/group accession cell in dl-table.
+create_modal_callback(
+    table_id="dl-table",
+    modal_id="accession-modal",
+    content_id="accession-modal-content",
+    title_id="accession-modal-title",
 )


### PR DESCRIPTION
# Summary
- Fix stored/reflected XSS in the universal accession modal (`assets/js/universal-modal.js`) by escaping all user/DB-sourced values before `innerHTML` interpolation and URL-encoding accession/tax-id values dropped into external links (JGI, NCBI, sequence viewer).
- Replace the ship/group accession popup with a native `dmc.Modal` rendered server-side (`src/components/data.py`, `src/pages/wiki.py`, `src/components/callbacks.py`), removing the old clientside callback and raw HTML string concatenation path in favor of Dash Mantine components.
- Admin grid: add an "Add row" action that inserts a new editable row and routes it through a new whitelisted `_do_insert` path in `save_all_pending` (`src/pages/admin.py`), alongside existing update handling.
- Add `md5` and `sequence_length` columns to `captains` (mirroring `ships`), with an index on `md5` for duplicate-sequence lookups (`alembic/versions/l5m6n7o8p9q0_...py`, `src/database/models/schema.py`). Backfill for existing rows is handled by a separate cleanup script, not the migration.
- Add `invalidate_meta_and_ship_cache()` helper to clear the query cache after bulk DB writes from maintenance/cleanup scripts (`src/config/cache.py`).